### PR TITLE
fix unit test by capturing the stdout in buffer for compare

### DIFF
--- a/internal/core/commands.go
+++ b/internal/core/commands.go
@@ -14,7 +14,7 @@ var PwdCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		dir, err := os.Getwd()
 		checkError(err, "getting current working directory")
-		fmt.Println(dir)
+		fmt.Fprintln(cmd.OutOrStdout(), dir)
 	},
 }
 


### PR DESCRIPTION
hi @IshaanNene ,
this pr fixes the failing tests in unit pkg. issues with original tests was it was not correctly capturing the stdout from actual cmd execution. By setting the cmd stdout to test buffer, we can now capture it and use it for cmd. 

#2 